### PR TITLE
[BENCHMARKS 2/x] Add containerd specific logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 /benchmark/bin
 /benchmark/output.json
+/benchmark/containerd-out

--- a/benchmark/framework/containerd_utils.go
+++ b/benchmark/framework/containerd_utils.go
@@ -1,0 +1,172 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/log/logtest"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+)
+
+var (
+	testNamespace = "BENCHMARK_TESTING"
+)
+
+type ContainerdProcess struct {
+	command       *exec.Cmd
+	address       string
+	root          string
+	state         string
+	output        *os.File
+	Client        *containerd.Client
+	Context       context.Context
+	cancelContext context.CancelFunc
+}
+
+func StartContainerd(
+	b *testing.B,
+	containerdAddress string,
+	containerdRoot string,
+	containerdState string,
+	containerdConfig string,
+	containerdOutput string) (*ContainerdProcess, error) {
+	containerdCmd := exec.Command("containerd",
+		"-a", containerdAddress,
+		"--root", containerdRoot,
+		"--state", containerdState,
+		"-c", containerdConfig)
+	outfile, err := os.Create(containerdOutput)
+	if err != nil {
+		return nil, err
+	}
+	containerdCmd.Stdout = outfile
+	containerdCmd.Stderr = outfile
+	err = containerdCmd.Start()
+	if err != nil {
+		return nil, err
+	}
+	client, err := newClient(containerdAddress)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancelCtx := testContext(b)
+
+	return &ContainerdProcess{
+		command:       containerdCmd,
+		address:       containerdAddress,
+		root:          containerdRoot,
+		output:        outfile,
+		state:         containerdState,
+		Client:        client,
+		Context:       ctx,
+		cancelContext: cancelCtx}, nil
+}
+
+func (proc *ContainerdProcess) StopProcess() {
+	if proc.Client != nil {
+		proc.Client.Close()
+	}
+	if proc.output != nil {
+		proc.output.Close()
+	}
+	if proc.cancelContext != nil {
+		proc.cancelContext()
+	}
+	if proc.command != nil {
+		proc.command.Process.Kill()
+	}
+	os.RemoveAll(proc.root)
+	os.RemoveAll(proc.state)
+	os.RemoveAll(proc.address)
+}
+
+func (proc *ContainerdProcess) PullImage(
+	imageRef string,
+	platform string) (containerd.Image, error) {
+	image, pullErr := proc.Client.Pull(proc.Context, imageRef, GetRemoteOpts(proc.Context, platform)...)
+	if pullErr != nil {
+		return nil, pullErr
+	}
+	return image, nil
+}
+
+func (proc *ContainerdProcess) RunContainer(image containerd.Image) error {
+	id := "TEST_RUN_CONTAINER"
+	container, err := proc.Client.NewContainer(
+		proc.Context,
+		id,
+		containerd.WithNewSnapshot(id, image),
+		containerd.WithNewSpec(oci.WithImageConfig(image)))
+	if err != nil {
+		return err
+	}
+	defer container.Delete(proc.Context, containerd.WithSnapshotCleanup)
+
+	task, err := container.NewTask(proc.Context, cio.NewCreator(cio.WithStdio))
+	if err != nil {
+		return err
+	}
+	defer task.Delete(proc.Context)
+
+	exitStatusC, err := task.Wait(proc.Context)
+	if err != nil {
+		return err
+	}
+
+	if err := task.Start(proc.Context); err != nil {
+		return err
+	}
+	status := <-exitStatusC
+	_, _, err = status.Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetRemoteOpts(ctx context.Context, platform string) []containerd.RemoteOpt {
+	var opts []containerd.RemoteOpt
+	opts = append(opts, containerd.WithPlatform(platform))
+	opts = append(opts, containerd.WithPullUnpack)
+
+	return opts
+}
+
+func testContext(t testing.TB) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = namespaces.WithNamespace(ctx, testNamespace)
+	if t != nil {
+		ctx = logtest.WithT(ctx, t)
+	}
+	return ctx, cancel
+}
+
+func newClient(address string) (*containerd.Client, error) {
+	opts := []containerd.ClientOpt{}
+	if rt := os.Getenv("TEST_RUNTIME"); rt != "" {
+		opts = append(opts, containerd.WithDefaultRuntime(rt))
+	}
+
+	return containerd.New(address, opts...)
+}


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

This PR builds on BASE_BENCHMARK and is compared against it

### Description of changes:
This PR makes two main contributions:
- it adds a new file to the framework packge _containerd_utils.go_ which is used to house all of the containerd related niceties.  In particular it adds an object *ContainerdProcess* that makes it easy to start, stop, and interact with a custom containerd instance.
- It also adds working Benchmark tests for pulling and running containers.  Replacing the trivial example tests

Currently it pulls a trivial hello world container from dockerhub and runs it.

### Testing performed:
Ran `make && make check && make benchmarks`
Benchmark results:
```
{
 "commit": "08de8c7b60650f0375708c9c934bc3e4242d1b57",
 "benchmarkTests": [
  {
   "testName": "DockerPullImage",
   "numberOfTests": 10,
   "testsRun": 0,
   "stdDev": 0.017812883866331005,
   "mean": 0.3587444877,
   "min": 0.340562198,
   "pct25": 0.3450049245,
   "pct50": 0.351049845,
   "pct75": 0.36519452500000005,
   "pct90": 0.3749149,
   "max": 0.401132685
  },
  {
   "testName": "DockerRunContainer",
   "numberOfTests": 10,
   "testsRun": 0,
   "stdDev": 0.012508549045107044,
   "mean": 0.1498946318,
   "min": 0.124643698,
   "pct25": 0.1406955555,
   "pct50": 0.147301395,
   "pct75": 0.156558903,
   "pct90": 0.163900576,
   "max": 0.170168455
  }
 ]
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
