### PR TITLE
[BENCHMARKS 3/x] Add input file for images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,4 @@ integration:
 
 benchmarks:
 	@echo "$@"
-	@cd benchmark/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o bin/benchmarkTests main.go && sudo ./bin/benchmarkTests $(COMMIT)
+	@cd benchmark/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o bin/benchmarkTests . && sudo ./bin/benchmarkTests $(COMMIT) imagesToRun.csv

--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+)
+
+func BenchmarkPullImage(b *testing.B, imageRef string) {
+	containerdProcess, err := framework.StartContainerd(
+		b,
+		containerdAddress,
+		containerdRoot,
+		containerdState,
+		containerdConfig,
+		containerdOutput)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer containerdProcess.StopProcess()
+	b.ResetTimer()
+	_, err = containerdProcess.PullImage(imageRef, platform)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkRunContainer(b *testing.B, imageRef string) {
+	containerdProcess, err := framework.StartContainerd(
+		b,
+		containerdAddress,
+		containerdRoot,
+		containerdState,
+		containerdConfig,
+		containerdOutput)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer containerdProcess.StopProcess()
+	image, err := containerdProcess.PullImage(imageRef, platform)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	err = containerdProcess.RunContainer(image)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StopTimer()
+}

--- a/benchmark/imagesToRun.csv
+++ b/benchmark/imagesToRun.csv
@@ -1,0 +1,1 @@
+HelloWorld,docker.io/library/hello-world:latest


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

### Description of changes:
This PR adds functionality to pass in a csv file as an argument to benchmark binary.  As of now it just passes in a shortName (e.g. HelloWorld) and an imageRef (e.g. docker.io/library/hello-world:latest).  This is valuable as it allows us to remove hardcoding of images and push this functionality into the config file.

Note this also moves tests from the main file to their own file, just so that we can reduce the number of lines in main.go.

### Testing performed:
`make && make check && make benchmarks`

Output was inline with expectations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
